### PR TITLE
Create HTTP module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,13 @@ anyhow = { version = "1", features = ["backtrace"] }
 log = { version = "0.4", default-features = false }
 esp-idf-svc = { version = "0.47.1", default-features = false }
 embedded-svc = { version = "0.26", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_urlencoded = "0.7"
 toml-cfg = "0.1.3"
+hyper = "0.14.27"
+mime = "0.3.17"
+encoding_rs = "0.8.33"
 
 [build-dependencies]
 embuild = "0.31.4"

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -9,7 +9,7 @@ use esp_idf_svc::log::EspLogger;
 use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
 use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
 
-use lynx_embedded::{connect_wifi, reqwesp};
+use lynx_embedded::{reqwesp, wifi as espWifi};
 
 #[allow(dead_code)]
 #[derive(Deserialize, Debug)]
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
         sys_loop,
     )?;
 
-    connect_wifi(&mut wifi)?;
+    espWifi::connect(&mut wifi)?;
 
     let mut client = reqwesp::Client::new()?;
     // Endpoint for testing REST requests

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use hyper::header::CONTENT_TYPE;
+use serde::{Deserialize, Serialize};
+
+use esp_idf_svc::hal::prelude::Peripherals;
+use esp_idf_svc::log::EspLogger;
+use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
+use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
+
+use lynx_embedded::{connect_wifi, reqwesp};
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+struct Anything {
+    pub data: String,
+    pub json: Option<Account>,
+    pub method: String,
+    pub origin: String,
+    pub url: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Account {
+    username: String,
+    password: String,
+}
+
+fn main() -> Result<()> {
+    // Bind the log crate to the ESP Logging facilities
+    EspLogger::initialize_default();
+
+    // Configure Wifi
+    let peripherals = Peripherals::take().unwrap();
+    let sys_loop = EspSystemEventLoop::take()?;
+    let nvs = EspDefaultNvsPartition::take()?;
+
+    let mut wifi = BlockingWifi::wrap(
+        EspWifi::new(peripherals.modem, sys_loop.clone(), Some(nvs))?,
+        sys_loop,
+    )?;
+
+    connect_wifi(&mut wifi)?;
+
+    let mut client = reqwesp::Client::new()?;
+    // Endpoint for testing REST requests
+    let url = "https://httpbin.org/anything";
+
+    {
+        // Send `GET` request
+        log::info!("`GET` request");
+
+        let mut req = client.get(url);
+        let res = req.send()?;
+
+        log::info!(
+            "Status Code: {}, URL: {}, Content-Type: {:?}",
+            res.status(),
+            res.url(),
+            res.header(CONTENT_TYPE.as_str()).unwrap()
+        );
+
+        let res_text = res.text()?;
+        log::info!("Full Response: {res_text}");
+    }
+
+    {
+        // Send `POST` request with json body
+        log::info!("`POST` request with json body");
+
+        let mut req = client.post(url).json(&Account {
+            username: "crab".to_string(),
+            password: "ferris".to_string(),
+        });
+        let res = req.send()?;
+
+        log::info!(
+            "Status Code: {}, URL: {}, Content-Type: {:?}",
+            res.status(),
+            res.url(),
+            res.header(CONTENT_TYPE.as_str()).unwrap()
+        );
+
+        let res_json: Anything = res.json()?;
+        log::info!("json field: {:?}", res_json.json);
+
+        if let Some(acc) = res_json.json {
+            log::info!("Sent username: {}", acc.username);
+            log::info!("Sent password: {}", acc.password);
+        }
+    }
+
+    {
+        // Send `POST` request with form body
+        log::info!("`POST` request with form body");
+
+        let mut params = HashMap::new();
+        params.insert("lang", "rust");
+        params.insert("pancakes", "🥞");
+
+        let mut req = client.post(url).form(&params);
+        let res = req.send()?;
+
+        log::info!(
+            "Status Code: {}, URL: {}, Content-Type: {:?}",
+            res.status(),
+            res.url(),
+            res.header(CONTENT_TYPE.as_str()).unwrap()
+        );
+
+        let res_text = res.text()?;
+        log::info!("Full Response: {res_text}");
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
 mod wifi;
 pub use wifi::connect_wifi;
+
+pub mod reqwesp;
+use reqwesp::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-mod wifi;
-pub use wifi::connect_wifi;
+pub mod wifi;
 
 pub mod reqwesp;
 use reqwesp::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 
-use lynx_embedded::connect_wifi;
-
 use esp_idf_svc::hal::prelude::Peripherals;
 use esp_idf_svc::log::EspLogger;
 use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
 use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
+
+use lynx_embedded::wifi as espWifi;
 
 fn main() -> Result<()> {
     // Bind the log crate to the ESP Logging facilities
@@ -21,7 +21,7 @@ fn main() -> Result<()> {
         sys_loop,
     )?;
 
-    connect_wifi(&mut wifi)?;
+    espWifi::connect(&mut wifi)?;
     log::info!("Wifi connected!");
 
     Ok(())

--- a/src/reqwesp/client.rs
+++ b/src/reqwesp/client.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use hyper::HeaderMap;
+
+use embedded_svc::http::client::Client as HttpClient;
+use embedded_svc::http::Method;
+use esp_idf_svc::http::client::{Configuration as HttpConfig, EspHttpConnection};
+
+use crate::{Request, RequestBuilder};
+
+pub struct Client {
+    client: HttpClient<EspHttpConnection>,
+}
+
+impl<'a> Client {
+    /// Constructs a new `Client`.
+    pub fn new() -> Result<Self> {
+        Ok(Client {
+            client: Self::create_http_client()?,
+        })
+    }
+
+    /// Start building a `Request` with the `Method` and url.
+    pub fn request(&'a mut self, method: Method, url: &'a str) -> RequestBuilder {
+        RequestBuilder {
+            client: &mut self.client,
+            headers: HeaderMap::new(),
+            request: Ok(Request {
+                method,
+                url,
+                headers: Box::new([]),
+                body: None,
+            }),
+        }
+    }
+
+    /// Convenience method to make a `GET` request to a URL.
+    pub fn get(&'a mut self, url: &'a str) -> RequestBuilder {
+        self.request(Method::Get, url)
+    }
+
+    /// Convenience method to make a `POST` request to a URL.
+    pub fn post(&'a mut self, url: &'a str) -> RequestBuilder {
+        self.request(Method::Post, url)
+    }
+
+    /// Convenience method to make a `PUT` request to a URL.
+    pub fn put(&'a mut self, url: &'a str) -> RequestBuilder {
+        self.request(Method::Put, url)
+    }
+
+    /// Convenience method to make a `DELETE` request to a URL.
+    pub fn delete(&'a mut self, url: &'a str) -> RequestBuilder {
+        self.request(Method::Delete, url)
+    }
+
+    /// Create a new `HttpClient` with a `EspHttpConnection` handler.
+    fn create_http_client() -> Result<HttpClient<EspHttpConnection>> {
+        // Create HTTPS Connection Handler
+        let connection = EspHttpConnection::new(&HttpConfig {
+            use_global_ca_store: true,
+            crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
+            ..Default::default()
+        })?;
+
+        // Create HTTPS Client
+        let client = HttpClient::wrap(connection);
+        Ok(client)
+    }
+}

--- a/src/reqwesp/error.rs
+++ b/src/reqwesp/error.rs
@@ -1,0 +1,191 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use hyper::StatusCode;
+
+pub trait HttpError: StdError + Send + Sync + 'static {}
+impl<T> HttpError for T where T: StdError + Send + Sync + 'static {}
+
+pub struct Error<E: HttpError> {
+    inner: Box<Inner<E>>,
+}
+
+struct Inner<E: HttpError> {
+    kind: Kind,
+    source: Option<E>,
+    url: Option<String>,
+}
+
+impl<E: HttpError> Error<E> {
+    pub(crate) fn new(kind: Kind, source: Option<E>) -> Error<E> {
+        Error {
+            inner: Box::new(Inner {
+                kind,
+                source: source.map(Into::into),
+                url: None,
+            }),
+        }
+    }
+
+    pub fn url(&self) -> Option<&String> {
+        self.inner.url.as_ref()
+    }
+
+    /// Returns a mutable reference to the URL related to this error
+    ///
+    /// This is useful if you need to remove sensitive information from the URL
+    /// (e.g. an API key in the query), but do not want to remove the URL
+    /// entirely.
+    pub fn url_mut(&mut self) -> Option<&mut String> {
+        self.inner.url.as_mut()
+    }
+
+    /// Add a url related to this error (overwriting any existing)
+    pub fn with_url(mut self, url: String) -> Self {
+        self.inner.url = Some(url);
+        self
+    }
+
+    /// Strip the related url from this error (if, for example, it contains
+    /// sensitive information)
+    pub fn without_url(mut self) -> Self {
+        self.inner.url = None;
+        self
+    }
+
+    /// Returns true if the error is from a type Builder.
+    pub fn is_builder(&self) -> bool {
+        matches!(self.inner.kind, Kind::Builder)
+    }
+
+    /// Returns true if the error is from a `RedirectPolicy`.
+    pub fn is_redirect(&self) -> bool {
+        matches!(self.inner.kind, Kind::Redirect)
+    }
+
+    /// Returns true if the error is from `Response::error_for_status`.
+    pub fn is_status(&self) -> bool {
+        matches!(self.inner.kind, Kind::Status(_))
+    }
+
+    /// Returns true if the error is related to the request
+    pub fn is_request(&self) -> bool {
+        matches!(self.inner.kind, Kind::Request)
+    }
+
+    /// Returns true if the error is related to the request or response body
+    pub fn is_body(&self) -> bool {
+        matches!(self.inner.kind, Kind::Body)
+    }
+
+    /// Returns true if the error is related to decoding the response's body
+    pub fn is_decode(&self) -> bool {
+        matches!(self.inner.kind, Kind::Decode)
+    }
+
+    /// Returns the status code, if the error was generated from a response.
+    pub fn status(&self) -> Option<StatusCode> {
+        match self.inner.kind {
+            Kind::Status(code) => Some(code),
+            _ => None,
+        }
+    }
+}
+
+impl<E: HttpError> fmt::Debug for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut builder = f.debug_struct("reqwesp::Error");
+
+        builder.field("kind", &self.inner.kind);
+
+        if let Some(ref url) = self.inner.url {
+            builder.field("url", url);
+        }
+        if let Some(ref source) = self.inner.source {
+            builder.field("source", source);
+        }
+
+        builder.finish()
+    }
+}
+
+impl<E: HttpError> fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.inner.kind {
+            Kind::Builder => f.write_str("builder error")?,
+            Kind::Request => f.write_str("error sending request")?,
+            Kind::Body => f.write_str("request or response body error")?,
+            Kind::Decode => f.write_str("error decoding response body")?,
+            Kind::Redirect => f.write_str("error following redirect")?,
+            Kind::Upgrade => f.write_str("error upgrading connection")?,
+            Kind::Status(ref code) => {
+                let prefix = if code.is_client_error() {
+                    "HTTP status client error"
+                } else {
+                    debug_assert!(code.is_server_error());
+                    "HTTP status server error"
+                };
+                write!(f, "{prefix} ({code})")?;
+            }
+        };
+
+        if let Some(url) = &self.inner.url {
+            write!(f, " for url ({})", url.as_str())?;
+        }
+
+        if let Some(e) = &self.inner.source {
+            write!(f, ": {e}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<E: HttpError> StdError for Error<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.inner.source.as_ref().map(|e| e as _)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum Kind {
+    Builder,
+    Request,
+    Redirect,
+    Status(StatusCode),
+    Body,
+    Decode,
+    Upgrade,
+}
+
+// constructors
+
+pub(crate) fn builder(e: impl HttpError) -> anyhow::Error {
+    anyhow::Error::new(Error::new(Kind::Builder, Some(e)))
+}
+
+#[allow(dead_code)]
+pub(crate) fn body(e: impl HttpError) -> anyhow::Error {
+    anyhow::Error::new(Error::new(Kind::Body, Some(e)))
+}
+
+pub(crate) fn decode(e: impl HttpError) -> anyhow::Error {
+    anyhow::Error::new(Error::new(Kind::Decode, Some(e)))
+}
+
+#[allow(dead_code)]
+pub(crate) fn request(e: impl HttpError) -> anyhow::Error {
+    anyhow::Error::new(Error::new(Kind::Request, Some(e)))
+}
+
+#[allow(dead_code)]
+pub(crate) fn redirect(e: impl HttpError, url: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(Error::new(Kind::Redirect, Some(e)).with_url(url.into()))
+}
+
+pub(crate) fn status_code(url: impl Into<String>, status: StatusCode) -> anyhow::Error {
+    anyhow::Error::new(
+        Error::new(Kind::Status(status), None::<hyper::http::Error>).with_url(url.into()),
+    )
+}

--- a/src/reqwesp/mod.rs
+++ b/src/reqwesp/mod.rs
@@ -1,0 +1,10 @@
+mod client;
+pub use client::Client;
+
+mod request;
+pub use request::{Request, RequestBuilder};
+
+mod response;
+pub use response::Response;
+
+pub mod error;

--- a/src/reqwesp/request.rs
+++ b/src/reqwesp/request.rs
@@ -1,0 +1,125 @@
+use anyhow::{bail, Result};
+use hyper::header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
+use hyper::http::HeaderName;
+use hyper::HeaderMap;
+use serde::Serialize;
+
+use embedded_svc::http::client::Client as HttpClient;
+use embedded_svc::http::Method;
+use esp_idf_svc::http::client::EspHttpConnection;
+
+use crate::Response;
+
+pub struct Request<'a> {
+    pub(crate) method: Method,
+    pub(crate) url: &'a str,
+    pub(crate) headers: Box<[(&'a str, &'a str)]>,
+    pub(crate) body: Option<Vec<u8>>,
+}
+
+pub struct RequestBuilder<'a> {
+    pub(crate) client: &'a mut HttpClient<EspHttpConnection>,
+    pub(crate) headers: HeaderMap,
+    pub(crate) request: Result<Request<'a>>,
+}
+
+impl<'a> RequestBuilder<'a> {
+    /// Constructs the `Request` and sends it to the target URL, returning a `Response`.
+    pub fn send(&'a mut self) -> Result<Response<'a>> {
+        match &mut self.request {
+            Ok(ref mut request) => {
+                // Convert from HeaderMap to a boxed slice used for the request
+                request.headers = self
+                    .headers
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.to_str().unwrap()))
+                    .collect::<Vec<(&str, &str)>>()
+                    .into_boxed_slice();
+
+                Response::new(self.client, request)
+            }
+            Err(err) => bail!(err.to_string()),
+        }
+    }
+
+    // TODO implement build method for returning a constructed `Request`.
+    //  Must update `Request` headers with `RequestBuilder` headers before returning.
+    // pub fn build(self) -> Result<Request<'a>> {
+    //     self.request
+    // }
+
+    /// Add a header to this request.
+    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
+        self.headers.insert(key, value);
+        self
+    }
+
+    /// Add multiple headers to this request.
+    pub fn headers(mut self, headers: Vec<(HeaderName, HeaderValue)>) -> Self {
+        for (key, value) in headers.into_iter() {
+            self.headers.insert(key, value);
+        }
+        self
+    }
+
+    /// Add a body to this request.
+    pub fn body(mut self, data: &[u8]) -> Self {
+        let content_length_header = data.len().to_string();
+        if let Ok(ref mut req) = self.request {
+            req.body = Some(data.to_vec());
+        }
+        self.header(CONTENT_LENGTH, content_length_header.parse().unwrap())
+    }
+
+    // TODO Add method to modify the query string of the URL.
+    //  Consider finding an external crate for parsing and handling URLs.
+    // pub fn query<T: Serialize + ?Sized>(mut self, query: &T) -> Self {}
+
+    /// Send a form body.
+    pub fn form<T: Serialize + ?Sized>(mut self, form: &'a T) -> Self {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            match serde_urlencoded::to_string(form) {
+                Ok(body) => {
+                    let content_length_header = body.len().to_string();
+                    self.headers
+                        .insert(CONTENT_LENGTH, content_length_header.parse().unwrap());
+                    self.headers.insert(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/x-www-form-urlencoded"),
+                    );
+                    req.body = Some(body.into());
+                }
+                Err(err) => error = Some(crate::error::builder(err)),
+            }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
+        }
+        self
+    }
+
+    /// Add a json body to this request.
+    pub fn json(mut self, json: &impl Serialize) -> Self {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            match serde_json::to_vec(json) {
+                Ok(body) => {
+                    let content_length_header = body.len().to_string();
+                    self.headers
+                        .insert(CONTENT_LENGTH, content_length_header.parse().unwrap());
+                    if !self.headers.contains_key(CONTENT_TYPE) {
+                        self.headers
+                            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                    }
+                    req.body = Some(body);
+                }
+                Err(err) => error = Some(err),
+            }
+        }
+        if let Some(err) = error {
+            self.request = Err(anyhow::Error::from(err));
+        }
+        self
+    }
+}

--- a/src/reqwesp/response.rs
+++ b/src/reqwesp/response.rs
@@ -23,11 +23,11 @@ impl<'a> Response<'a> {
         client: &'a mut HttpClient<EspHttpConnection>,
         request: &'a Request<'a>,
     ) -> Result<Self> {
-        let mut req = client.request(request.method, request.url, &request.headers)?;
+        let mut req = client.request(request.method, request.url, request.headers.as_slice())?;
 
         if let Some(data) = &request.body {
             log::debug!("Adding data to request: {} bytes", data.len());
-            req.write_all(data.as_slice())?;
+            req.write_all(data)?;
             req.flush()?;
         }
 

--- a/src/reqwesp/response.rs
+++ b/src/reqwesp/response.rs
@@ -1,0 +1,146 @@
+use anyhow::Result;
+use encoding_rs::{Encoding, UTF_8};
+use hyper::body::Bytes;
+use hyper::header::HeaderValue;
+use hyper::StatusCode;
+use mime::Mime;
+use serde::de::DeserializeOwned;
+
+use embedded_svc::http::client::{Client as HttpClient, Response as HttpResponse};
+use embedded_svc::io::Write;
+use esp_idf_svc::http::client::EspHttpConnection;
+
+use crate::reqwesp::Request;
+
+pub struct Response<'a> {
+    body: Bytes,
+    res: HttpResponse<&'a mut EspHttpConnection>,
+    url: &'a str,
+}
+
+impl<'a> Response<'a> {
+    pub(crate) fn new(
+        client: &'a mut HttpClient<EspHttpConnection>,
+        request: &'a Request<'a>,
+    ) -> Result<Self> {
+        let mut req = client.request(request.method, request.url, &request.headers)?;
+
+        if let Some(data) = &request.body {
+            log::debug!("Adding data to request: {} bytes", data.len());
+            req.write_all(data.as_slice())?;
+            req.flush()?;
+        }
+
+        let mut response = Self {
+            body: Bytes::new(),
+            res: req.submit()?,
+            url: request.url,
+        };
+        response.read()?;
+        Ok(response)
+    }
+
+    // Read the `HttpResponse` into the `Response` body as `Bytes`.
+    fn read(&mut self) -> Result<()> {
+        // Use a vector so we don't need to know the max size of the response
+        let mut data = Vec::new();
+        let mut buf = [0u8; 256];
+        // Read into buffer and append to vector until the reader is empty
+        loop {
+            let size = self.res.read(&mut buf)?;
+            if size == 0 {
+                break;
+            }
+            data.extend_from_slice(&buf[..size])
+        }
+
+        self.body = Bytes::from(data);
+        Ok(())
+    }
+
+    /// Get the `StatusCode` of this `Response`.
+    pub fn status(&self) -> StatusCode {
+        match StatusCode::from_u16(self.res.status()) {
+            Ok(status) => status,
+            Err(_) => {
+                log::error!("Invalid response status code");
+                StatusCode::BAD_REQUEST
+            }
+        }
+    }
+
+    /// Get the final URL of this `Response`.
+    pub fn url(&self) -> &str {
+        self.url
+    }
+
+    /// Obtain the given header.
+    pub fn header(&self, name: &str) -> Option<HeaderValue> {
+        let raw_value = self.res.header(name)?;
+        match HeaderValue::from_str(raw_value) {
+            Ok(header) => Some(header),
+            Err(_) => {
+                log::error!(
+                    "Header value for exists, but is invalid: name=`{name}`, value=`{raw_value}`"
+                );
+                None
+            }
+        }
+    }
+
+    /// Get the full response text.
+    pub fn text(self) -> Result<String> {
+        self.text_with_charset("utf-8")
+    }
+
+    /// Get the full response text given a specific encoding.
+    pub fn text_with_charset(self, default_encoding: &str) -> Result<String> {
+        let content_type = self
+            .header("Content-Type")
+            .as_ref()
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<Mime>().ok());
+
+        let encoding_name = content_type
+            .as_ref()
+            .and_then(|mime| mime.get_param("charset").map(|charset| charset.as_str()))
+            .unwrap_or(default_encoding);
+        let encoding = Encoding::for_label(encoding_name.as_bytes()).unwrap_or(UTF_8);
+
+        let full = self.bytes();
+
+        let (text, _, _) = encoding.decode(&full);
+        Ok(text.into_owned())
+    }
+
+    /// Try to deserialize the response body as JSON.
+    pub fn json<T: DeserializeOwned>(self) -> Result<T> {
+        let full = self.bytes();
+        serde_json::from_slice(&full).map_err(crate::error::decode)
+    }
+
+    /// Get the full response body as `Bytes`.
+    pub fn bytes(self) -> Bytes {
+        self.body
+    }
+
+    /// Turn a response into an error if the server returned an error.
+    pub fn error_for_status(self) -> Result<Self> {
+        let status = self.status();
+        if status.is_client_error() || status.is_server_error() {
+            Err(crate::error::status_code(self.url, status))
+        } else {
+            Ok(self)
+        }
+    }
+
+    /// Turn a reference to a response into an error if the server returned an error.
+    pub fn error_for_status_ref(&self) -> Result<&Self> {
+        let status = self.status();
+        if status.is_client_error() || status.is_server_error() {
+            Err(crate::error::status_code(self.url, status))
+        } else {
+            Ok(self)
+        }
+    }
+}

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -4,14 +4,14 @@ use embedded_svc::wifi::{AuthMethod, ClientConfiguration, Configuration};
 use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
 
 #[toml_cfg::toml_config]
-pub struct Config {
+pub(crate) struct Config {
     #[default("")]
     wifi_ssid: &'static str,
     #[default("")]
     wifi_password: &'static str,
 }
 
-pub fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> Result<()> {
+pub fn connect(wifi: &mut BlockingWifi<EspWifi<'static>>) -> Result<()> {
     let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
         ssid: CONFIG.wifi_ssid.into(),
         password: CONFIG.wifi_password.into(),


### PR DESCRIPTION
Implemented a HTTP client that is compatible with ESP-IDF.
The module is mostly modelled after the structure of the [reqwest](https://crates.io/crates/reqwest) crate, which is the most widely used HTTP client for Rust.

An example showing its usage is included in this PR.