### PR TITLE
Add module for onboard addressable RGB LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Run and monitor the program:
 Flash the program:
 
 ```bash
-./esp-cargo espflash flash --release --example http
+./esp-cargo espflash flash --release --example led
 ```
 
 Run and monitor the program:
 
 ```bash
-./esp-cargo run --example http
+./esp-cargo run --example led
 ```
 
 ## Usage: Local Environment
@@ -113,13 +113,13 @@ cargo run
 Flash the program:
 
 ```bash
-cargo espflash flash --release --example http
+cargo espflash flash --release --example led
 ```
 
 Run and monitor the program:
 
 ```bash
-cargo run --example http
+cargo run --example led
 ```
 
 ## Troubleshooting

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -1,0 +1,45 @@
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use esp_idf_svc::log::EspLogger;
+
+use lynx_embedded::Led;
+
+fn main() -> Result<()> {
+    // Bind the log crate to the ESP Logging facilities
+    EspLogger::initialize_default();
+
+    //LED
+    log::info!("Let's use the esp32c3 rgb led!");
+
+    let mut led = Led::new(
+        esp_idf_svc::sys::rmt_channel_t_RMT_CHANNEL_0,
+        esp_idf_svc::sys::gpio_num_t_GPIO_NUM_8,
+    )?;
+
+    log::info!("Setting 1");
+    led.set_color(0x10, 0x00, 0x00)?;
+    thread::sleep(Duration::from_millis(1000));
+    log::info!("Setting 2");
+    led.set_color(0x00, 0x10, 0x00)?;
+    thread::sleep(Duration::from_millis(1000));
+    log::info!("Setting 3");
+    led.set_color(0x00, 0x00, 0x10)?;
+    thread::sleep(Duration::from_millis(1000));
+
+    const L: u8 = 0x00;
+    const H: u8 = 0x05;
+    const DURATION: Duration = Duration::from_millis(10);
+    const NUM_STEPS: u32 = 20;
+    led.fade_to(L, L, L, 5, DURATION)?;
+    loop {
+        led.fade_to(H, L, L, NUM_STEPS, DURATION)?;
+        led.fade_to(H, H, L, NUM_STEPS, DURATION)?;
+        led.fade_to(L, H, L, NUM_STEPS, DURATION)?;
+        led.fade_to(L, H, H, NUM_STEPS, DURATION)?;
+        led.fade_to(L, L, H, NUM_STEPS, DURATION)?;
+        led.fade_to(H, L, H, NUM_STEPS, DURATION)?;
+    }
+}

--- a/src/led_strip.rs
+++ b/src/led_strip.rs
@@ -1,0 +1,230 @@
+// Modified from https://github.com/fkohlgrueber/esp32c3-idf-led-example
+use std::{ffi::c_void, thread, time::Duration};
+
+use esp_idf_svc::sys::{
+    esp_err_t, gpio_num_t, rmt_carrier_level_t_RMT_CARRIER_LEVEL_HIGH,
+    rmt_carrier_level_t_RMT_CARRIER_LEVEL_LOW, rmt_channel_t, rmt_config_t,
+    rmt_config_t__bindgen_ty_1, rmt_mode_t_RMT_MODE_TX, rmt_tx_config_t, ESP_OK,
+};
+
+const WS2812_T0H_NS: u32 = 350;
+const WS2812_T0L_NS: u32 = 1000;
+const WS2812_T1H_NS: u32 = 1000;
+const WS2812_T1L_NS: u32 = 350;
+//const WS2812_RESET_US: u32 = 280;
+
+#[derive(Debug)]
+pub struct EspError {
+    inner: esp_err_t,
+}
+
+impl std::fmt::Display for EspError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "esp error code: {}", self.inner)
+    }
+}
+
+impl std::error::Error for EspError {}
+
+fn esp_res(err_code: esp_err_t) -> Result<(), EspError> {
+    if err_code == ESP_OK {
+        Ok(())
+    } else {
+        Err(EspError { inner: err_code })
+    }
+}
+
+pub type Led = LedStrip<1>;
+
+#[derive(Debug)]
+pub struct LedStrip<const NUM_LEDS: usize> {
+    ws2812_t0h_ticks: u32,
+    ws2812_t0l_ticks: u32,
+    ws2812_t1h_ticks: u32,
+    ws2812_t1l_ticks: u32,
+    buffer: [[u8; 3]; NUM_LEDS],
+    channel: rmt_channel_t,
+}
+
+impl<const NUM_LEDS: usize> LedStrip<NUM_LEDS> {
+    pub fn new(rmt_channel: rmt_channel_t, gpio_num: gpio_num_t) -> Result<Self, EspError> {
+        let config = rmt_config_t {
+            rmt_mode: rmt_mode_t_RMT_MODE_TX,
+            gpio_num,
+            channel: rmt_channel,
+            clk_div: 2,
+            mem_block_num: 1,
+            flags: 0,
+            __bindgen_anon_1: rmt_config_t__bindgen_ty_1 {
+                tx_config: rmt_tx_config_t {
+                    carrier_freq_hz: 38000,
+                    carrier_level: rmt_carrier_level_t_RMT_CARRIER_LEVEL_HIGH,
+                    idle_level: rmt_carrier_level_t_RMT_CARRIER_LEVEL_LOW,
+                    carrier_duty_percent: 33,
+                    carrier_en: false,
+                    loop_en: false,
+                    idle_output_en: true,
+                    loop_count: 0,
+                },
+            },
+        };
+
+        let config_ptr: *const rmt_config_t = &config;
+        unsafe {
+            esp_res(esp_idf_svc::sys::rmt_config(config_ptr))?;
+            esp_res(esp_idf_svc::sys::rmt_driver_install(config.channel, 0, 0))?;
+        }
+
+        let mut counter_clk_hz: u32 = 0;
+        unsafe {
+            esp_res(esp_idf_svc::sys::rmt_get_counter_clock(
+                config.channel,
+                &mut counter_clk_hz,
+            ))?;
+        }
+
+        let ratio = counter_clk_hz as f32 / 1e9;
+
+        let ws2812_t0h_ticks = (ratio * WS2812_T0H_NS as f32) as u32;
+        let ws2812_t0l_ticks = (ratio * WS2812_T0L_NS as f32) as u32;
+        let ws2812_t1h_ticks = (ratio * WS2812_T1H_NS as f32) as u32;
+        let ws2812_t1l_ticks = (ratio * WS2812_T1L_NS as f32) as u32;
+
+        unsafe {
+            esp_res(esp_idf_svc::sys::rmt_translator_init(
+                config.channel,
+                Some(Self::adapter),
+            ))?;
+        }
+
+        let led_strip = LedStrip {
+            ws2812_t0h_ticks,
+            ws2812_t0l_ticks,
+            ws2812_t1h_ticks,
+            ws2812_t1l_ticks,
+            buffer: [[0, 0, 0]; NUM_LEDS],
+            channel: rmt_channel,
+        };
+        Ok(led_strip)
+    }
+
+    unsafe extern "C" fn adapter(
+        src: *const c_void,
+        dest: *mut esp_idf_svc::sys::rmt_item32_t,
+        src_size: usize,
+        wanted_num: usize,
+        translated_size: *mut usize,
+        item_num: *mut usize,
+    ) {
+        if src.is_null() || dest.is_null() {
+            *translated_size = 0;
+            *item_num = 0;
+            return;
+        }
+        let led_strip_p: *const Self = src.cast();
+        let led_strip_ref: &Self = &*led_strip_p;
+        let bit0 = Self::get_rmt_item32(
+            led_strip_ref.ws2812_t0h_ticks,
+            1,
+            led_strip_ref.ws2812_t0l_ticks,
+            0,
+        );
+        let bit1 = Self::get_rmt_item32(
+            led_strip_ref.ws2812_t1h_ticks,
+            1,
+            led_strip_ref.ws2812_t1l_ticks,
+            0,
+        );
+        let mut size = 0;
+        let mut num = 0;
+        let mut psrc: *const u8 = led_strip_ref.buffer.as_ptr().cast();
+        let mut pdest = dest;
+        while size < src_size && num < wanted_num {
+            for i in 0..8 {
+                // MSB first
+                if *psrc & (1 << (7 - i)) != 0 {
+                    (*pdest) = bit1;
+                } else {
+                    (*pdest) = bit0;
+                }
+                num += 1;
+                pdest = pdest.add(1);
+            }
+            size += 1;
+            psrc = psrc.add(1);
+        }
+        *translated_size = size;
+        *item_num = num;
+    }
+
+    fn get_rmt_item32(
+        duration0: u32,
+        level0: u32,
+        duration1: u32,
+        level1: u32,
+    ) -> esp_idf_svc::sys::rmt_item32_t {
+        let mut tmp = esp_idf_svc::sys::rmt_item32_t__bindgen_ty_1__bindgen_ty_1::default();
+        tmp.set_duration0(duration0);
+        tmp.set_duration1(duration1);
+        tmp.set_level0(level0);
+        tmp.set_level1(level1);
+
+        esp_idf_svc::sys::rmt_item32_t {
+            __bindgen_anon_1: esp_idf_svc::sys::rmt_item32_t__bindgen_ty_1 {
+                __bindgen_anon_1: tmp,
+            },
+        }
+    }
+}
+
+impl<const NUM_LEDS: usize> Drop for LedStrip<NUM_LEDS> {
+    fn drop(&mut self) {
+        unsafe {
+            esp_idf_svc::sys::rmt_driver_uninstall(self.channel);
+        }
+    }
+}
+
+impl LedStrip<1> {
+    pub fn set_color(&mut self, red: u8, green: u8, blue: u8) -> Result<(), EspError> {
+        self.buffer[0] = [green, red, blue];
+        self.update()
+    }
+
+    fn update(&mut self) -> Result<(), EspError> {
+        unsafe {
+            esp_res(esp_idf_svc::sys::rmt_write_sample(
+                self.channel,
+                (self as *mut Self).cast(),
+                3,
+                true,
+            ))?;
+            esp_res(esp_idf_svc::sys::rmt_wait_tx_done(self.channel, 1_000_000))?;
+        }
+        Ok(())
+    }
+
+    pub fn fade_to(
+        &mut self,
+        red: u8,
+        green: u8,
+        blue: u8,
+        num_steps: u32,
+        delay_per_step: Duration,
+    ) -> Result<(), EspError> {
+        let from_color = self.buffer[0];
+        let to_color = [green, red, blue];
+
+        for x in 1..=num_steps {
+            for i in 0..3 {
+                self.buffer[0][i] = ((to_color[i] as u32 * x
+                    + from_color[i] as u32 * (num_steps - x))
+                    / num_steps) as u8;
+            }
+            self.update()?;
+            thread::sleep(delay_per_step);
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,6 @@ pub mod wifi;
 
 pub mod reqwesp;
 use reqwesp::*;
+
+mod led_strip;
+pub use led_strip::Led;


### PR DESCRIPTION
This module was modified from https://github.com/fkohlgrueber/esp32c3-idf-led-example (credit is given in a comment at the top of the file as well).

It uses some of the raw bindings for the ESP-IDF SDK (anything from  [`esp_idf_svc::sys`](https://github.com/esp-rs/esp-idf-sys)), which is why it requires some `unsafe` blocks. 